### PR TITLE
Add Docker support for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Cache and data
+cache/
+chromadb/
+*.db
+*.sqlite
+*.log
+
+# Documentation
+*.md
+!README.md
+
+# Tests
+tests/
+.pytest_cache/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# API Keys for Ask-PanDA (set at least one)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
+MISTRAL_API_KEY=your_mistral_api_key_here
+LLAMA_API_URL=http://localhost:11434/api/generate
+
+# Ollama Shim Configuration
+OLLAMA_SHIM_MODEL=mistral
+OLLAMA_SHIM_MODEL_DISPLAY=mistral-proxy
+OLLAMA_SHIM_VERSION=v0.0-shim

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 ask_panda_server.log
 error_analyzer.log
 *.log
-
+/chromadb/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Ask PanDA FastAPI service container image
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+# System packages required for faiss-cpu, sentence-transformers, and HTTPS downloads
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Ensure data directories exist even if volumes are mounted later
+RUN mkdir -p cache chromadb resources
+
+VOLUME ["/app/cache", "/app/chromadb"]
+
+EXPOSE 8000
+
+CMD ["uvicorn", "ask_panda_server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.shim
+++ b/Dockerfile.shim
@@ -1,0 +1,22 @@
+# Ollama Shim service container image
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Install minimal dependencies for the shim
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        fastapi==0.115.5 \
+        uvicorn==0.32.1 \
+        httpx==0.28.1
+
+# Copy only the shim script
+COPY ollama_shim.py .
+
+EXPOSE 11434
+
+CMD ["python", "ollama_shim.py"]

--- a/ask_panda_server.py
+++ b/ask_panda_server.py
@@ -155,6 +155,10 @@ class PandaMCP(FastMCP):
     async def _call_mistral(self, prompt: str) -> str:
         """
         Use the official Mistral SDK for cleaner, more reliable API calls.
+
+        Model: mistral-large-latest
+        Note: Requires appropriate API tier access. Can be changed to
+              mistral-small-latest or open-mistral-7b for lower tiers.
         """
         api_key = os.getenv("MISTRAL_API_KEY")
         if not api_key:

--- a/ask_panda_server.py
+++ b/ask_panda_server.py
@@ -431,3 +431,48 @@ async def rag_ask(request: QuestionRequest) -> dict[str, str]:
 
     logger.info(f"Query processed using model '{request.model.lower()}'.")
     return {"answer": response_text}
+
+
+@app.post("/agent_ask")
+async def agent_ask(request: QuestionRequest) -> dict[str, str]:
+    """
+    Full agent routing endpoint - routes questions to specialized agents.
+    """
+    from agents.selection_agent import SelectionAgent, figure_out_agents
+
+    logger.info(f"Agent query: '{request.question}' using model: '{request.model}'")
+
+    try:
+        agents = figure_out_agents(
+            request.question,
+            request.model.lower(),
+            session_id="api",
+            cache="/app/cache"
+        )
+
+        selection_agent = SelectionAgent(agents, request.model.lower())
+        category = selection_agent.answer(request.question)
+        agent = agents.get(category)
+
+        logger.info(f"Routed to: {category}")
+
+        if category == "document":
+            answer = agent.ask(request.question)
+        elif category == "log_analyzer":
+            question = agent.generate_question("pilotlog.txt")
+            answer = agent.ask(question)
+        elif category == "task":
+            question = agent.generate_question()
+            answer = agent.ask(question)
+        else:
+            answer = "Not yet implemented"
+
+        if isinstance(answer, dict):
+            final_answer = answer.get("answer", "No answer provided")
+        else:
+            final_answer = answer
+
+        return {"answer": final_answer, "category": category}
+    except Exception as e:
+        logger.error(f"Agent error: {e}")
+        return {"answer": f"Error: {str(e)}", "category": "error"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+# Ask-PanDA Docker Compose Configuration
+# ========================================
+# This setup runs Ask-PanDA with an Ollama-compatible shim for Open WebUI integration.
+#
+# Services:
+#   - ask-panda: Main RAG server with Mistral API backend (port 8001)
+#   - ollama-shim: Ollama API compatibility layer (port 11435)
+#
+# Usage:
+#   docker compose up -d          # Start services
+#   docker compose logs -f        # View logs
+#   docker compose down           # Stop services
+#   ./test-docker-setup.sh        # Test the setup
+#
+# Configuration:
+#   Copy .env.example to .env and add your MISTRAL_API_KEY
+#
+services:
+  ask-panda:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ask-panda:latest
+    container_name: ask-panda-server
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./cache:/app/cache
+      - ./chromadb:/app/chromadb
+      - ./resources:/app/resources
+    environment:
+      # Add your API keys here or use .env file
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
+      - LLAMA_API_URL=${LLAMA_API_URL:-}
+    networks:
+      - ask-panda-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  ollama-shim:
+    build:
+      context: .
+      dockerfile: Dockerfile.shim
+    image: ollama-shim:latest
+    container_name: ollama-shim
+    ports:
+      # Map internal 11434 to external 11435 to avoid conflict with localhost Ollama
+      - "11435:11434"
+    environment:
+      # Point to the ask-panda service in the Docker network
+      - ASK_PANDA_BASE_URL=http://ask-panda:8000
+      - OLLAMA_SHIM_MODEL=${OLLAMA_SHIM_MODEL:-mistral}
+      - OLLAMA_SHIM_MODEL_DISPLAY=${OLLAMA_SHIM_MODEL_DISPLAY:-mistral-proxy}
+      - OLLAMA_SHIM_PORT=11434
+      - OLLAMA_SHIM_VERSION=${OLLAMA_SHIM_VERSION:-v0.0-shim}
+    networks:
+      - ask-panda-network
+    depends_on:
+      ask-panda:
+        condition: service_healthy
+    restart: unless-stopped
+
+networks:
+  ask-panda-network:
+    driver: bridge

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,180 @@
+# Docker Deployment Guide
+
+This directory contains Docker-related files for containerized deployment of the Ask PanDA FastAPI service.
+
+## Files
+
+- **`../Dockerfile`**: Container image definition (located in project root)
+- **`run_askpanda.sh`**: Helper script to start the container with proper configuration
+- **`stop_askpanda.sh`**: Helper script to stop the running container
+
+## Prerequisites
+
+- Docker installed and running
+- API keys for at least one LLM provider (Anthropic, OpenAI, Gemini, or Mistral)
+- PanDA authentication tokens (optional, for PanDA-specific features)
+
+## Quick Start
+
+### 1. Build the Docker Image
+
+From the project root directory:
+
+```bash
+docker build -t ask-panda .
+```
+
+### 2. Configure Environment Variables
+
+The `run_askpanda.sh` script uses environment variables for configuration. You can either:
+
+**Option A**: Export them before running the script:
+
+```bash
+export ANTHROPIC_API_KEY='your_anthropic_api_key'
+export OPENAI_API_KEY='your_openai_api_key'
+export GEMINI_API_KEY='your_gemini_api_key'
+export MISTRAL_API_KEY='your_mistral_api_key'
+```
+
+**Option B**: Edit `run_askpanda.sh` directly and set the default values (lines 22-26).
+
+### 3. Start the Container
+
+```bash
+./docker/run_askpanda.sh
+```
+
+The service will be available at `http://localhost:8000`
+
+### 4. Stop the Container
+
+```bash
+./docker/stop_askpanda.sh
+```
+
+## Configuration Options
+
+The `run_askpanda.sh` script supports several environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IMAGE_TAG` | `ask-panda` | Docker image tag to use |
+| `CONTAINER_NAME` | `ask-panda` | Name for the running container |
+| `CACHE_DIR` | `/tmp/ask-panda-cache` | Host directory for cache persistence |
+| `CHROMA_DIR` | `${PROJECT_ROOT}/chromadb` | Host directory for ChromaDB data |
+| `RESOURCES_DIR` | `${PROJECT_ROOT}/resources` | Host directory for resource files |
+| `OIDC_AUTH_TOKEN_PATH` | `/secure/path/panda_primary.token` | Path to PanDA OIDC token |
+| `PANDA_AUTH_TOKEN_KEY_PATH` | `/secure/path/panda.key` | Path to PanDA auth key |
+| `OIDC_AUTH_ORIGIN` | `atlas.pilot` | OIDC authentication origin |
+| `ANTHROPIC_API_KEY` | - | Anthropic (Claude) API key |
+| `OPENAI_API_KEY` | - | OpenAI (GPT) API key |
+| `GEMINI_API_KEY` | - | Google Gemini API key |
+| `MISTRAL_API_KEY` | - | Mistral AI API key |
+
+### Example with Custom Configuration
+
+```bash
+export IMAGE_TAG="ask-panda:latest"
+export CONTAINER_NAME="my-ask-panda"
+export CACHE_DIR="/var/cache/ask-panda"
+export ANTHROPIC_API_KEY="sk-ant-..."
+./docker/run_askpanda.sh
+```
+
+## Volume Mounts
+
+The container uses the following volume mounts:
+
+- **`/app/cache`**: Stores cached data and downloaded files
+- **`/app/chromadb`**: Persistent storage for the ChromaDB vector database
+- **`/app/resources`**: Read-only mount for resource documents (optional)
+- **`/tokens/`**: Read-only mount for PanDA authentication tokens (optional)
+
+## Manual Docker Run
+
+If you prefer not to use the helper scripts, you can run the container manually:
+
+```bash
+docker run --rm \
+  --name ask-panda \
+  -p 8000:8000 \
+  -v /tmp/ask-panda-cache:/app/cache \
+  -v ./chromadb:/app/chromadb \
+  -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+  -e OPENAI_API_KEY="${OPENAI_API_KEY}" \
+  -e GEMINI_API_KEY="${GEMINI_API_KEY}" \
+  -e MISTRAL_API_KEY="${MISTRAL_API_KEY}" \
+  ask-panda
+```
+
+## Accessing the Service
+
+Once the container is running, you can access the FastAPI service:
+
+- **API Documentation**: http://localhost:8000/docs
+- **Alternative API Docs**: http://localhost:8000/redoc
+- **Health Check**: http://localhost:8000/
+
+## Troubleshooting
+
+### Container won't start
+
+Check that:
+- Port 8000 is not already in use: `lsof -i :8000`
+- At least one API key is set
+- Docker daemon is running
+
+### Volume mount errors
+
+Ensure the host directories exist and have proper permissions:
+
+```bash
+mkdir -p /tmp/ask-panda-cache
+mkdir -p ./chromadb
+mkdir -p ./resources
+```
+
+### View container logs
+
+```bash
+docker logs ask-panda
+```
+
+Or for continuous log streaming:
+
+```bash
+docker logs -f ask-panda
+```
+
+## Building for Production
+
+For production deployments, consider:
+
+1. **Using a specific tag**: `docker build -t ask-panda:1.0.0 .`
+2. **Multi-stage builds**: Optimize image size if needed
+3. **Health checks**: Add Docker health check configuration
+4. **Resource limits**: Set memory and CPU limits
+5. **Restart policy**: Use `--restart unless-stopped` for automatic restarts
+
+Example production run:
+
+```bash
+docker run -d \
+  --name ask-panda \
+  --restart unless-stopped \
+  -p 8000:8000 \
+  -v /var/lib/ask-panda/cache:/app/cache \
+  -v /var/lib/ask-panda/chromadb:/app/chromadb \
+  --memory="2g" \
+  --cpus="1.0" \
+  -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+  ask-panda:1.0.0
+```
+
+## Notes
+
+- The Dockerfile is located in the project root directory (one level up from this docker/ directory)
+- The container runs as a non-privileged user for security
+- All Python dependencies are installed from `requirements.txt`
+- The vector store is automatically created from documents in the `resources/` directory when the server starts

--- a/docker/run_askpanda.sh
+++ b/docker/run_askpanda.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Helper script to start the Ask PanDA container with common mounts and secrets.
+#
+# Fill in the environment variables below (or export them before calling)
+# to point at your PanDA token files and API keys. The script defaults to
+# the locally built image tag "ask-panda".
+
+set -euo pipefail
+
+# ---- User-configurable settings ----
+IMAGE_TAG="${IMAGE_TAG:-ask-panda}"
+CONTAINER_NAME="${CONTAINER_NAME:-ask-panda}"
+
+# Location on the host where you want cached PanDA artefacts to persist
+CACHE_DIR="${CACHE_DIR:-/tmp/ask-panda-cache}"
+
+# Paths to the local token files (set to actual token locations)
+OIDC_AUTH_TOKEN_PATH="${OIDC_AUTH_TOKEN_PATH:-/secure/path/panda_primary.token}"
+PANDA_AUTH_TOKEN_KEY_PATH="${PANDA_AUTH_TOKEN_KEY_PATH:-/secure/path/panda.key}"
+OIDC_AUTH_ORIGIN="${OIDC_AUTH_ORIGIN:-atlas.pilot}"
+
+# API keys for LLM providers (set whichever you plan to use)
+MISTRAL_API_KEY="${MISTRAL_API_KEY:-}"
+OPENAI_API_KEY="${OPENAI_API_KEY:-}"
+ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
+GEMINI_API_KEY="${GEMINI_API_KEY:-}"
+
+# ---- Derived paths ----
+# Script is in docker/ subdirectory, so go up one level to project root
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHROMA_DIR="${CHROMA_DIR:-${PROJECT_ROOT}/chromadb}"
+RESOURCES_DIR="${RESOURCES_DIR:-${PROJECT_ROOT}/resources}"
+
+# Ensure cache directory exists on the host
+mkdir -p "${CACHE_DIR}"
+
+# Assemble Docker run command
+docker run --rm \
+  --name "${CONTAINER_NAME}" \
+  -p 8000:8000 \
+  -v "${CACHE_DIR}:/app/cache" \
+  -v "${CHROMA_DIR}:/app/chromadb" \
+  -v "${RESOURCES_DIR}:/app/resources:ro" \
+  -v "${OIDC_AUTH_TOKEN_PATH}:/tokens/panda_primary.token:ro" \
+  -v "${PANDA_AUTH_TOKEN_KEY_PATH}:/tokens/panda.key:ro" \
+  -e OIDC_AUTH_TOKEN="/tokens/panda_primary.token" \
+  -e PANDA_AUTH_TOKEN_KEY="/tokens/panda.key" \
+  -e OIDC_AUTH_ORIGIN="${OIDC_AUTH_ORIGIN}" \
+  -e MISTRAL_API_KEY="${MISTRAL_API_KEY}" \
+  -e OPENAI_API_KEY="${OPENAI_API_KEY}" \
+  -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+  -e GEMINI_API_KEY="${GEMINI_API_KEY}" \
+  "${IMAGE_TAG}"

--- a/docker/stop_askpanda.sh
+++ b/docker/stop_askpanda.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stop the Ask PanDA container started via run_askpanda.sh.
+
+set -euo pipefail
+
+CONTAINER_NAME="${CONTAINER_NAME:-ask-panda}"
+
+if docker ps --format '{{.Names}}' | grep -Fxq "${CONTAINER_NAME}"; then
+  docker stop "${CONTAINER_NAME}"
+else
+  echo "Container '${CONTAINER_NAME}' is not running."
+fi

--- a/ollama_shim.py
+++ b/ollama_shim.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+ollama_shim.py
+──────────────────────────────────────────────────────────────────────
+Minimal Ollama-compatible façade for Ask-PanDA.
+
+This FastAPI application exposes the handful of endpoints that Open WebUI
+expects from an Ollama server. Instead of talking to a local Ollama daemon,
+each request is forwarded to the Ask-PanDA HTTP API, which in turn uses the
+Mistral API (or any other LLM provider configured inside Ask-PanDA).
+
+Current Configuration:
+    - Backend: Ask-PanDA RAG endpoint (`/rag_ask`)
+    - LLM: Mistral API (open-mistral-7b model)
+    - Model exposed: mistral-proxy:latest
+    - Default port: 11434 (11435 in Docker to avoid conflicts)
+
+Endpoints implemented:
+    GET  /api/tags      → model listing with :latest tag support
+    GET  /api/ps        → running models list
+    GET  /api/version   → version information
+    POST /api/chat      → translate chat requests to Ask-PanDA RAG
+    POST /api/generate  → translate generate requests to Ask-PanDA RAG
+
+Environment Variables:
+    ASK_PANDA_BASE_URL       - Ask-PanDA server URL (default: http://localhost:8000)
+    OLLAMA_SHIM_MODEL        - Backend model name (default: mistral)
+    OLLAMA_SHIM_MODEL_DISPLAY - Display name for Open WebUI (default: mistral-proxy)
+    OLLAMA_SHIM_PORT         - Port to listen on (default: 11434)
+    OLLAMA_SHIM_VERSION      - Version string (default: v0.0-shim)
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Ask-PanDA Ollama Shim", version="0.1.0")
+
+ASK_PANDA_BASE_URL = os.getenv("ASK_PANDA_BASE_URL", "http://localhost:8000")
+# Use rag_ask for both endpoints - agent_ask has timeout issues with complex processing
+ASK_PANDA_AGENT_ENDPOINT = f"{ASK_PANDA_BASE_URL.rstrip('/')}/rag_ask"
+ASK_PANDA_RAG_ENDPOINT = f"{ASK_PANDA_BASE_URL.rstrip('/')}/rag_ask"
+
+OLLAMA_SHIM_MODEL = os.getenv("OLLAMA_SHIM_MODEL", "mistral")
+OLLAMA_SHIM_MODEL_DISPLAY = os.getenv(
+    "OLLAMA_SHIM_MODEL_DISPLAY", f"{OLLAMA_SHIM_MODEL}-proxy"
+)
+OLLAMA_VERSION = os.getenv("OLLAMA_SHIM_VERSION", "v0.0-shim")
+
+
+def _utcnow_iso() -> str:
+    return _dt.datetime.utcnow().isoformat() + "Z"
+
+
+def _normalize_model_name(model_name: Optional[str]) -> str:
+    """
+    Strip the :latest or other tags from model names for Ask-PanDA compatibility.
+    Converts 'mistral-proxy:latest' -> 'mistral' using the configured base model.
+    """
+    if not model_name:
+        return OLLAMA_SHIM_MODEL
+
+    # Strip any tag (e.g., :latest)
+    base_name = model_name.split(":")[0]
+
+    # If it matches our display name, use the configured backend model
+    if base_name == OLLAMA_SHIM_MODEL_DISPLAY.split(":")[0]:
+        return OLLAMA_SHIM_MODEL
+
+    return base_name
+
+
+def _extract_user_prompt(messages: List[Dict[str, Any]]) -> str:
+    """
+    Collapse an Ollama `messages` list into a single text prompt.
+
+    The simplest workable strategy (sufficient for the shim) is to concatenate
+    the conversation using `role:` prefixes. The last user message is the one
+    we send to Ask-PanDA, prefixed with short context for continuity.
+    """
+    if not messages:
+        return ""
+
+    history_lines = [f"{msg.get('role', 'unknown')}: {msg.get('content', '')}".strip()
+                     for msg in messages[:-1]]
+    last_msg = messages[-1]
+    last_user = last_msg.get("content", "")
+
+    history_prefix = "\n".join(history_lines).strip()
+    if history_prefix:
+        combined = f"{history_prefix}\nuser: {last_user}"
+    else:
+        combined = last_user
+    return combined.strip()
+
+
+async def _call_ask_panda(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        async with httpx.AsyncClient(timeout=90.0) as client:
+            logger.debug("Posting to %s with payload %s", endpoint, payload)
+            response = await client.post(endpoint, json=payload)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        msg = f"Ask-PanDA returned {exc.response.status_code}: {exc.response.text}"
+        logger.error(msg)
+        raise HTTPException(status_code=exc.response.status_code, detail=msg)
+    except httpx.RequestError as exc:
+        msg = f"Failed to reach Ask-PanDA: {exc}"
+        logger.error(msg)
+        raise HTTPException(status_code=502, detail=msg)
+
+    try:
+        return response.json()
+    except ValueError:
+        msg = "Ask-PanDA response was not valid JSON"
+        logger.error(msg)
+        raise HTTPException(status_code=502, detail=msg)
+
+
+@app.get("/api/tags")
+async def list_models() -> Dict[str, Any]:
+    """
+    Mirror Ollama's /api/tags to satisfy Open WebUI model discovery.
+    """
+    # Ensure model name includes :latest tag for compatibility
+    model_name = OLLAMA_SHIM_MODEL_DISPLAY
+    if ":" not in model_name:
+        model_name = f"{model_name}:latest"
+
+    payload = {
+        "models": [
+            {
+                "name": model_name,
+                "model": model_name,
+                "modified_at": _utcnow_iso(),
+            }
+        ]
+    }
+    return payload
+
+
+@app.get("/api/ps")
+async def list_running_models() -> Dict[str, Any]:
+    """
+    Report a fake running model list. This is primarily for UI niceties.
+    """
+    # Ensure model name includes :latest tag for compatibility
+    model_name = OLLAMA_SHIM_MODEL_DISPLAY
+    if ":" not in model_name:
+        model_name = f"{model_name}:latest"
+
+    payload = {
+        "models": [
+            {
+                "name": model_name,
+                "model": model_name,
+                "digest": "shim",
+                "size": 0,
+                "details": {},
+                "expires_at": None,
+            }
+        ]
+    }
+    return payload
+
+
+@app.get("/api/version")
+async def version() -> Dict[str, Any]:
+    """
+    Provide a synthetic version string.
+    """
+    return {"version": OLLAMA_VERSION}
+
+
+@app.post("/api/chat")
+async def chat(request: Request) -> JSONResponse:
+    """
+    Emulate Ollama's /api/chat endpoint by forwarding the last user prompt to
+    Ask-PanDA's agent endpoint.
+    """
+    data: Dict[str, Any] = await request.json()
+
+    messages: Optional[List[Dict[str, Any]]] = data.get("messages")
+    if not messages:
+        raise HTTPException(status_code=400, detail="messages is required")
+
+    prompt = _extract_user_prompt(messages)
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Could not extract user prompt")
+
+    # Normalize model name (strip :latest tag, map to backend model)
+    requested_model = data.get("model")
+    model_id = _normalize_model_name(requested_model)
+
+    ask_payload = {"question": prompt, "model": model_id}
+    ask_response = await _call_ask_panda(ASK_PANDA_AGENT_ENDPOINT, ask_payload)
+
+    answer = ask_response.get("answer", "")
+    response_body = {
+        "model": requested_model or OLLAMA_SHIM_MODEL_DISPLAY,
+        "created_at": _utcnow_iso(),
+        "message": {"role": "assistant", "content": answer},
+    }
+
+    return JSONResponse(response_body)
+
+
+@app.post("/api/generate")
+async def generate(request: Request) -> JSONResponse:
+    """
+    Minimal support for Ollama's /api/generate endpoint (prompt-based).
+    """
+    data: Dict[str, Any] = await request.json()
+    prompt = data.get("prompt")
+    if not prompt:
+        raise HTTPException(status_code=400, detail="prompt is required")
+
+    # Normalize model name (strip :latest tag, map to backend model)
+    requested_model = data.get("model")
+    model_id = _normalize_model_name(requested_model)
+
+    ask_payload = {"question": prompt, "model": model_id}
+    ask_response = await _call_ask_panda(ASK_PANDA_RAG_ENDPOINT, ask_payload)
+
+    answer = ask_response.get("answer", "")
+    response_body = {
+        "model": requested_model or OLLAMA_SHIM_MODEL_DISPLAY,
+        "created_at": _utcnow_iso(),
+        "response": answer,
+        "done": True,
+    }
+    return JSONResponse(response_body)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("OLLAMA_SHIM_PORT", "11434"))
+    uvicorn.run("ollama_shim:app", host="0.0.0.0", port=port, reload=False)

--- a/open-webui/ask_panda_api_pipe.py
+++ b/open-webui/ask_panda_api_pipe.py
@@ -1,0 +1,45 @@
+"""
+AskPanDA API Pipe for Open WebUI
+
+This pipe calls the ask-panda HTTP API instead of importing Python code directly.
+Much simpler and avoids dependency conflicts!
+"""
+
+from typing import Any, List, Dict
+from pydantic import BaseModel, Field
+import requests
+
+
+class Pipe:
+    class Valves(BaseModel):
+        ask_panda_url: str = Field(
+            default="http://localhost:8000/agent_ask",
+            description="Ask PanDA endpoint",
+        )
+        model: str = Field(
+            default="gemini",
+            description="LLM model",
+        )
+
+    def __init__(self):
+        self.name = "Ask PanDA"
+        self.valves = self.Valves()
+
+    def pipe(
+        self,
+        user_message: str,
+        model_id: str,
+        messages: List[Dict[str, Any]],
+        body: Dict[str, Any],
+    ) -> str:
+        try:
+            r = requests.post(
+                self.valves.ask_panda_url,
+                json={"question": user_message, "model": self.valves.model},
+                timeout=90,
+            )
+            r.raise_for_status()
+            return r.json().get("answer", "No answer")
+        except Exception as e:
+            return f"Error: {e}"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anthropic
-chromadb==0.6.3
+chromadb>=1.0.0
 faiss-cpu
 fastapi
 fastmcp

--- a/resources/faq.txt
+++ b/resources/faq.txt
@@ -1,0 +1,31 @@
+Frequently asked questions.
+
+------------------------------------------------
+Question:
+How do I get help with using PanDA?
+
+Answer:
+In case of suggestions, questions, or problems with:
+* Running analysis: See ATLAS talk (https://atlas-talk.web.cern.ch/c/distributed-computing-help/17) or email DAST experts (hn-atlas-dist-analysis-help@cern.ch)
+* Monitoring: Write email to atlas-adc-pandamon-support@cern.ch or use mattermost (https://mattermost.web.cern.ch/adcvcr/channels/adc-bigpanda)
+------------------------------------------------
+Question:
+My task is not working
+
+Answer:
+Can you please provide the corresponding PanDA task ID
+------------------------------------------------
+Question:
+My job is not working
+
+Answer:
+Can you please provide the corresponding PanDA job ID
+------------------------------------------------
+Question:
+(user provided NUMBER)
+
+Answer:
+log_analyzer (only that and nothing else since it will be used by the selection agent - if the conversation is about a PanDA job)
+task (only that and nothing else since it will be used by the selection agent - if the conversation is about a PanDA task)
+unknown (if it is not clear from the conversation what the number means)
+------------------------------------------------

--- a/test-docker-setup.sh
+++ b/test-docker-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Test script for Docker setup
+
+set -e
+
+echo "=== Testing Docker Setup ==="
+echo
+
+echo "1. Checking if containers are running..."
+docker compose ps
+echo
+
+echo "2. Testing Ask-PanDA server (port 8001)..."
+curl -f http://localhost:8001/docs > /dev/null 2>&1 && \
+    echo "✓ Ask-PanDA server is accessible" || \
+    echo "✗ Ask-PanDA server is not accessible"
+echo
+
+echo "3. Testing Ollama shim (port 11435)..."
+curl -f http://localhost:11435/api/version 2>/dev/null && \
+    echo "✓ Ollama shim is accessible" || \
+    echo "✗ Ollama shim is not accessible"
+echo
+
+echo "4. Testing Ollama shim /api/tags endpoint..."
+curl -s http://localhost:11435/api/tags | python3 -m json.tool 2>/dev/null && \
+    echo "✓ Ollama shim /api/tags works" || \
+    echo "✗ Ollama shim /api/tags failed"
+echo
+
+echo "5. Checking Docker network..."
+docker network inspect ask-panda-network > /dev/null 2>&1 && \
+    echo "✓ Docker network 'ask-panda-network' exists" || \
+    echo "✗ Docker network not found"
+echo
+
+echo "=== Testing Complete ==="
+echo
+echo "To use with Open WebUI, set:"
+echo "  OLLAMA_BASE_URL=http://localhost:11435"

--- a/tools/vectorstore_manager.py
+++ b/tools/vectorstore_manager.py
@@ -28,7 +28,7 @@ from typing import List, Optional
 
 import chromadb
 from chromadb.config import Settings
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import TextLoader
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import Chroma


### PR DESCRIPTION
Files added:
- Dockerfile: Container image definition based on Python 3.11-slim
- docker/run_askpanda.sh: Helper script to start the container
- docker/stop_askpanda.sh: Helper script to stop the container
- docker/README.md: Comprehensive Docker deployment documentation

Dockerfile features:
- Python 3.11-slim base image for minimal footprint
- System dependencies: build-essential, curl, git, libgomp1
- Proper Python environment configuration
- Persistent volumes for cache and chromadb data
- Port 8000 exposed for FastAPI service
- Uvicorn server as default command

Helper scripts:
- run_askpanda.sh: Configurable startup with volume mounts, API keys, and PanDA authentication tokens
- stop_askpanda.sh: Clean container shutdown

Documentation:
- docker/README.md: Complete guide covering build, configuration, deployment, troubleshooting, and production considerations